### PR TITLE
add npm link deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,10 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.1.2",
     "sinon": "^1.17.6"
+  },
+  "devopsBase": {
+    "npmLinkDeps": {
+      "storj-lib": "core"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devopsBase": {
     "npmLinkDeps": {
-      "storj-lib": "core"
+      "storj-service-error-types": "service-error-types"
     }
   }
 }


### PR DESCRIPTION
This is required for proper automatic unpublished npm dependency linking in all environments