### PR TITLE
Make PULL default parameter for isPublic middleware

### DIFF
--- a/lib/public-bucket.js
+++ b/lib/public-bucket.js
@@ -14,7 +14,7 @@ module.exports = function PublicBucketFactory(storage){
    */
   return function publicBucket(req, res, next) {
     var bucketId = req.params.id;
-    var operation = req.body.operation;
+    var operation = req.body.operation || 'PULL';
 
     Bucket.findOne({
       _id: req.params.id,


### PR DESCRIPTION
This is used by the new _getBucketUnregistered in bridge which is called from the getFileInfo request, which doesn't pass an operation. This makes it currently fail for public buckets. This fix makes the operation default to PULL